### PR TITLE
Avoid passing an Int to stat

### DIFF
--- a/src/unix.jl
+++ b/src/unix.jl
@@ -202,7 +202,7 @@ _sem_destroy(sem::Ptr{Cvoid}) =
 #------------------------------------------------------------------------------
 # FILE DESCRIPTOR
 
-Base.stat(obj::FileDescriptor) = stat(obj.fd)
+Base.stat(obj::FileDescriptor) = stat(RawFD(obj.fd))
 
 function Base.open(::Type{FileDescriptor}, path::AbstractString,
                    flags::Integer, mode::Integer=DEFAULT_MODE)


### PR DESCRIPTION
This accommodates an upstream change to Julia (JuliaLang/julia#54855) which will, if merged, reduce confusion about `stat` and related methods. Specifically, by deprecating and/or removing the `stat(::Int)` method, in favor of `stat(::RawFD)`, we avoid issues like `ispath(4)` returning `true` (JuliaLang/julia#51710).

The current implementation of `stat` is, according to `@less stat(4)`, `stat(fd::Integer) = stat(RawFD(fd))`. So this PR should not change the functionality of this package.

https://github.com/JuliaLang/julia/blob/c3883824b00f378b7e2609c5e20f4a110e5e56e6/base/stat.jl#L192